### PR TITLE
Fix for off-by-one error in codeline() - issue #16

### DIFF
--- a/lib/Devel/ebug/Backend.pm
+++ b/lib/Devel/ebug/Backend.pm
@@ -82,7 +82,7 @@ sub DB {
   }
 
   $context->{watch_single} = 1;
-  $context->{codeline} = (fetch_codelines($filename, $line - 1))[0];
+  $context->{codeline} = (fetch_codelines($filename, $line))[0];
   chomp $context->{codeline};
 
   while (1) {


### PR DESCRIPTION
This fixes the error reported in issue #16 whereby two of the tests of codeline() were failing due to it returning an empty string. After applying this patch all tests pass for me. (Note that dzil bumped the version number in Makefile.PL but that I have not included that in this PR as it's up to you when to bump the version).

This work has been done as part of the [CPAN Pull Request Challenge](http://cpan-prc.org/) - thanks for taking part.