### PR TITLE
workaround weird test fail

### DIFF
--- a/t/ebug.t
+++ b/t/ebug.t
@@ -54,7 +54,8 @@ expect("", "main(corpus/calc.pl#5):\nmy \$e = add(\$q, \$w);", 'step again');
 expect("n", "main(corpus/calc.pl#6):\n\$e++;", 'next');
 expect("r", qq{main(corpus/calc.pl#9):\nprint "\$e\\n";}, 'run');
 expect("r", qq{}, 'run to end');
-expect("r", qq{Program finished. Enter 'restart' or 'q'}, 'run to end');
+expect_send('r');
+expect_like(qr{Program finished\. Enter 'restart' or 'q'}, 'run to end');
 expect_quit();
 exit;
 


### PR DESCRIPTION
I haven't been able to reproduce this test fail:

```
t/breakOnLoad.t ...... ok
t/codelines.t ........ ok

#   Failed test 'run to end'
#   at /home/cpan/pit/jail/oxzf_EpWgd/lib/perl5/Test/Expect.pm line 86.
#          got: 'Program finished. Enter 'restart' or 'q'r'
#     expected: 'Program finished. Enter 'restart' or 'q''
# Looks like you failed 1 test of 19.
t/ebug.t ............. 
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/19 subtests 
t/eval.t ............. ok
t/filenames.t ........ ok
t/finished.t ......... ok
```

but I think this should workaround this fail which I think is an issue (not necessarily a bug) `with Expect.pm`.